### PR TITLE
Fix import name for ProductDetailsPage and update route path

### DIFF
--- a/ikae/src/App.jsx
+++ b/ikae/src/App.jsx
@@ -13,7 +13,7 @@ import RegisterPage from "./pages/Register";
 import RoomEditor from "./scenes/RoomEditor/RoomEditor";
 import HomePage from "./pages/Home";
 import ProductsPage from "./pages/Products";
-import ProductDetailPage from "./pages/Details";
+import ProductDetailsPage from "./pages/Details";
 import CheckoutPage from "./pages/Checkout";
 import OrderSuccessPage from "./pages/Confirmation";
 import { AuthProvider } from "./components/Auth/AuthContext";
@@ -37,7 +37,7 @@ function App() {
           <Route path="/" element={<HomePage />} />
           <Route path="/products" element={<ProductsPage />} />
           <Route path="/details" element={<ProductDetailsPage />} />
-          <Route path="/products/:id" element={<ProductDetailPage />} />{" "}
+          <Route path="/products/:id" element={<ProductDetailsPage />} />{" "}
           <Route path="/checkout" element={<CheckoutPage />} />
           <Route path="/confirm" element={<OrderSuccessPage />} />
         </Routes>


### PR DESCRIPTION
This pull request includes a minor but important change to ensure consistency in the naming of the `ProductDetailsPage` component across the codebase.

### Naming consistency updates:

* [`ikae/src/App.jsx`](diffhunk://#diff-1551b93382a55a8b7358f21a632f22741dd311fc113ba9588dc235afecd955c0L16-R16): Corrected the import statement to rename `ProductDetailPage` to `ProductDetailsPage` for consistency.
* [`ikae/src/App.jsx`](diffhunk://#diff-1551b93382a55a8b7358f21a632f22741dd311fc113ba9588dc235afecd955c0L40-R40): Updated the route definition to use `ProductDetailsPage` instead of `ProductDetailPage` for the `/products/:id` route.